### PR TITLE
Allow directly creating TmpFileLazySeq/TmpFileLazySeqBuilders

### DIFF
--- a/src/main/scala/fm/lazyseq/TmpFileLazySeq.scala
+++ b/src/main/scala/fm/lazyseq/TmpFileLazySeq.scala
@@ -18,7 +18,7 @@ package fm.lazyseq
 import fm.common.{Resource, Serializer}
 import java.io.DataInput
 
-final private class TmpFileLazySeq[A](resource: Resource[DataInput])(implicit serializer: Serializer[A]) extends LazySeq[A] {
+final class TmpFileLazySeq[A](resource: Resource[DataInput])(implicit serializer: Serializer[A]) extends LazySeq[A] {
   private[this] val reader = SerializerReader(resource, serializer)
   
   final def foreach[U](f: A => U): Unit = reader.foreach(f)

--- a/src/main/scala/fm/lazyseq/TmpFileLazySeqBuilder.scala
+++ b/src/main/scala/fm/lazyseq/TmpFileLazySeqBuilder.scala
@@ -27,7 +27,7 @@ import scala.collection.mutable.Builder
  * 
  * Methods are synchronized so this should be thread-safe now
  */
-final private class TmpFileLazySeqBuilder[A](deleteTmpFiles: Boolean = true)(implicit serializer: Serializer[A]) extends Builder[A, LazySeq[A]] {
+final class TmpFileLazySeqBuilder[A](deleteTmpFiles: Boolean = true)(implicit serializer: Serializer[A]) extends Builder[A, LazySeq[A]] {
   def this(serializer: Serializer[A]) = this()(serializer)
   
   private[this] val tmpFile: File = File.createTempFile("TmpFileLazySeqBuilder", ".compressed")


### PR DESCRIPTION
Being able to create temporary,  file-based `LazySeq`s is extremely helpful functionality.  Make the constructors public.